### PR TITLE
feat: change sentryStackTrace update

### DIFF
--- a/frame.go
+++ b/frame.go
@@ -7,14 +7,14 @@ import (
 // A Frame represents a program counter inside a stack frame.
 type Frame struct {
 	// https://go.googlesource.com/go/+/032678e0fb/src/runtime/extern.go#169
-	frames [3]uintptr
+	frames []uintptr
 }
 
 // caller returns a Frame that describes a frame on the caller's stack.
 func caller(skip int) Frame {
-	var s Frame
-	runtime.Callers(skip+1, s.frames[:])
-	return s
+	f := [32]uintptr{}
+	n := runtime.Callers(skip+1, f[:])
+	return Frame{frames: f[:n]}
 }
 
 // location returns the function, file, and line number of a Frame.

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,7 @@ module github.com/ryomak/serrs
 
 go 1.18
 
-require (
-	github.com/getsentry/sentry-go v0.27.0
-	github.com/pkg/errors v0.9.1
-)
+require github.com/getsentry/sentry-go v0.27.0
 
 require (
 	golang.org/x/sys v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,7 +5,6 @@ github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxI
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=

--- a/sentry.go
+++ b/sentry.go
@@ -13,14 +13,11 @@ func (s *simpleError) StackTrace() []uintptr {
 	if origin == nil {
 		return frames
 	}
-	for _, frame := range origin.frame.frames {
-		frames = append(frames, frame)
+	frames = append(frames, origin.frame.frames...)
+	if len(frames) <= 1 {
+		return frames
 	}
-	if len(frames) > 1 {
-		frames = frames[1:]
-	}
-
-	return frames
+	return frames[1:]
 }
 
 // GenerateSentryEvent is a method to generate a sentry event from an error

--- a/sentry.go
+++ b/sentry.go
@@ -16,7 +16,7 @@ func (s *simpleError) StackTrace() []uintptr {
 	for _, frame := range origin.frame.frames {
 		frames = append(frames, frame)
 	}
-	if len(frames) > 0 {
+	if len(frames) > 1 {
 		frames = frames[1:]
 	}
 

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestGenerateSentryEvent_WithNilError(t *testing.T) {
+	t.Parallel()
+
 	event := serrs.GenerateSentryEvent(nil)
 	if event != nil {
 		t.Errorf("Expected nil, but got %v", event)
@@ -15,6 +17,8 @@ func TestGenerateSentryEvent_WithNilError(t *testing.T) {
 }
 
 func TestGenerateSentryEvent_WithUnknownErrorCode(t *testing.T) {
+	t.Parallel()
+
 	err := errors.New("test error")
 	event := serrs.GenerateSentryEvent(err)
 	if event.Contexts["error detail"]["code"] != "unknown" {
@@ -23,6 +27,8 @@ func TestGenerateSentryEvent_WithUnknownErrorCode(t *testing.T) {
 }
 
 func TestGenerateSentryEvent_WithKnownErrorCode(t *testing.T) {
+	t.Parallel()
+
 	err := serrs.Wrap(serrs.New(serrs.StringCode("known"), "test error"))
 	event := serrs.GenerateSentryEvent(err)
 	if event.Contexts["error detail"]["code"] != "known" {

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -1,0 +1,31 @@
+package serrs_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ryomak/serrs"
+)
+
+func TestGenerateSentryEvent_WithNilError(t *testing.T) {
+	event := serrs.GenerateSentryEvent(nil)
+	if event != nil {
+		t.Errorf("Expected nil, but got %v", event)
+	}
+}
+
+func TestGenerateSentryEvent_WithUnknownErrorCode(t *testing.T) {
+	err := errors.New("test error")
+	event := serrs.GenerateSentryEvent(err)
+	if event.Contexts["error detail"]["code"] != "unknown" {
+		t.Errorf("Expected 'unknown', but got %v", event.Contexts["error detail"]["code"])
+	}
+}
+
+func TestGenerateSentryEvent_WithKnownErrorCode(t *testing.T) {
+	err := serrs.Wrap(serrs.New(serrs.StringCode("known"), "test error"))
+	event := serrs.GenerateSentryEvent(err)
+	if event.Contexts["error detail"]["code"] != "known" {
+		t.Errorf("Expected 'known', but got %v", event.Contexts["error detail"]["code"])
+	}
+}


### PR DESCRIPTION
## 概要
- Sentryに送信するときのStackTraceはWrapした箇所のみ送る形だったが、error発生場所のスタックトレースを送るように変更

